### PR TITLE
Add Instrumentation test for Keygen feature

### DIFF
--- a/cryptolib/build.gradle.kts
+++ b/cryptolib/build.gradle.kts
@@ -58,7 +58,11 @@ dependencies {
     testImplementation ("org.mockito:mockito-core:5.14.2")
     testImplementation ("org.robolectric:robolectric:4.14.1")
 
+
     // Android instrumentation testing libraries
     androidTestImplementation ("androidx.test.ext:junit:1.2.1")
     androidTestImplementation ("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation ("androidx.work:work-testing:2.10.0")
+    androidTestImplementation ("androidx.test:core:1.6.1")
+
 }

--- a/cryptolib/src/androidTest/java/io/github/romantsisyk/cryptolib/keymanagement/KeyHelperIntegrationTest.kt
+++ b/cryptolib/src/androidTest/java/io/github/romantsisyk/cryptolib/keymanagement/KeyHelperIntegrationTest.kt
@@ -1,0 +1,46 @@
+package io.github.romantsisyk.cryptolib.keymanagement
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.romantsisyk.cryptolib.crypto.keymanagement.KeyHelper
+import io.github.romantsisyk.cryptolib.exceptions.KeyNotFoundException
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class KeyHelperIntegrationTest {
+
+    private val alias = "integrationTestAlias"
+
+    @After
+    fun tearDown() {
+        try {
+            KeyHelper.deleteKey(alias)
+        } catch (e: Exception) {
+            // Ignore cleanup errors
+        }
+    }
+
+    @Test
+    fun testFullKeyLifecycle() {
+        KeyHelper.generateAESKey(alias)
+        val generatedKey = KeyHelper.getAESKey(alias)
+        assertNotNull("Generated key should not be null", generatedKey)
+
+        val retrievedKey = KeyHelper.getAESKey(alias)
+        assertEquals("Generated key and retrieved key should match", generatedKey, retrievedKey)
+
+        val keys = KeyHelper.listKeys()
+        assertTrue("Generated key alias should appear in key list", keys.contains(alias))
+
+        KeyHelper.deleteKey(alias)
+        val remainingKeys = KeyHelper.listKeys()
+        assertFalse("Deleted key alias should not appear in key list", remainingKeys.contains(alias))
+    }
+
+    @Test(expected = KeyNotFoundException::class)
+    fun testRetrieveNonexistentKey() {
+        KeyHelper.getAESKey("nonexistentAlias")
+    }
+}

--- a/cryptolib/src/androidTest/java/io/github/romantsisyk/cryptolib/keymanagement/KeyRotationIntegrationTest.kt
+++ b/cryptolib/src/androidTest/java/io/github/romantsisyk/cryptolib/keymanagement/KeyRotationIntegrationTest.kt
@@ -1,0 +1,27 @@
+package io.github.romantsisyk.cryptolib.keymanagement
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.romantsisyk.cryptolib.crypto.keymanagement.KeyHelper
+import io.github.romantsisyk.cryptolib.crypto.keymanagement.KeyRotationManager
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class KeyRotationIntegrationTest {
+
+    @Test
+    fun testFullKeyRotationFlow() {
+        val alias = "testAlias"
+
+        KeyHelper.generateAESKey(alias, validityDays = -1)
+
+        val needsRotation = KeyRotationManager.isKeyRotationNeeded(alias)
+        assertTrue("Key should require rotation", needsRotation)
+
+        KeyRotationManager.rotateKeyIfNeeded(alias)
+
+        val keys = KeyHelper.listKeys()
+        assertTrue("New key alias should exist", keys.contains(alias))
+    }
+}

--- a/cryptolib/src/main/java/io/github/romantsisyk/cryptolib/crypto/keymanagement/KeyRotationManager.kt
+++ b/cryptolib/src/main/java/io/github/romantsisyk/cryptolib/crypto/keymanagement/KeyRotationManager.kt
@@ -46,4 +46,11 @@ object KeyRotationManager {
             Log.d(TAG, "Key '$alias' does not require rotation yet.")
         }
     }
+
+    fun isKeyRotationNeeded(alias: String): Boolean {
+        val keyInfo = KeyHelper.getKeyInfo(alias) ?: return false
+        val keyValidityEndDate = keyInfo.keyValidityForOriginationEnd ?: return false
+        val currentDate = Date()
+        return currentDate.after(keyValidityEndDate)
+    }
 }


### PR DESCRIPTION

#### Summary:
- [x] **Integration tests** added for the `KeyHelper` and `KeyRotationManager` classes.
- [x] Tests cover the lifecycle of cryptographic keys, including generation, retrieval, rotation, listing, and deletion.
